### PR TITLE
AW12: Add providers for usedApp and prismic to index; add missing prismic dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@mui/lab": "5.0.0-alpha.84",
         "@mui/material": "5.8.2",
         "@mui/styles": "5.8.0",
+        "@prismicio/client": "^6.6.1",
+        "@prismicio/react": "^2.4.2",
         "@types/react": "17.0.40",
         "@types/react-dom": "17.0.13",
         "@usedapp/core": "^1.0.1",
@@ -5849,6 +5851,73 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@prismicio/client": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.7.3.tgz",
+      "integrity": "sha512-zQVZhuQDYIgdaY636u+QNk2tvvbtpkaKsEiLT0Ef51nFW/y5fqpOG5U0eU3cVsikZaYNlZ17x6O1wmvVCLdimQ==",
+      "dependencies": {
+        "@prismicio/helpers": "^2.3.8",
+        "@prismicio/types": "^0.2.7"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@prismicio/helpers": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.8.tgz",
+      "integrity": "sha512-YHkEI2gHBRtNbMIEY8+ao9TLAqAMJSPbhGOAX9hiXHofcKSCBrpd9zaMxKNo5iXCWHnyBk1dsTsWXjKx0d1Rew==",
+      "dependencies": {
+        "@prismicio/richtext": "^2.1.3",
+        "@prismicio/types": "^0.2.7",
+        "escape-html": "^1.0.3",
+        "imgix-url-builder": "^0.0.3"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      }
+    },
+    "node_modules/@prismicio/react": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@prismicio/react/-/react-2.5.1.tgz",
+      "integrity": "sha512-gGF4UareQP1kdwtxNEbFyqWuFhQFqRjteMgsY7GxE0YKxKD3hByfUcKoFvSgkZIngk/boMpGRbRoE1S1Ouz2Jw==",
+      "dependencies": {
+        "@prismicio/helpers": "^2.3.8",
+        "@prismicio/richtext": "^2.1.3",
+        "@prismicio/types": "^0.2.7"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@prismicio/client": "^6",
+        "react": "^16.8 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "@prismicio/client": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prismicio/richtext": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.1.3.tgz",
+      "integrity": "sha512-5ZuR+43CSf0R50+Asim+9B6csAezDMA+IF3V6MKGV8aWbNaVWmI3nSNDlKVKAe3peYtpkwQa8oVtUL5rsoXRIg==",
+      "dependencies": {
+        "@prismicio/types": "^0.2.7"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      }
+    },
+    "node_modules/@prismicio/types": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.7.tgz",
+      "integrity": "sha512-xHPBWg+lPcl8U97VB/2oYK3MJlQoVPZq91hbeQO8WRyvq+zgpNST3xFOTk8SkQpgoH6wd50AxGZELvPrpojajQ==",
+      "engines": {
+        "node": ">=12.7.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -25684,6 +25753,14 @@
         "node": ">= 4"
       }
     },
+    "node_modules/imgix-url-builder": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.3.tgz",
+      "integrity": "sha512-8Oc2Cn4+jF06sEfJcVPlWYfD2F6RjrwIMbk1xEzux8unoB5LsvFc/GL1BQ47HPaeE12ReX2nMUcjUslGYWLxHA==",
+      "engines": {
+        "node": ">=12.7.0"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
@@ -44329,6 +44406,49 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
       "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
+    "@prismicio/client": {
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.7.3.tgz",
+      "integrity": "sha512-zQVZhuQDYIgdaY636u+QNk2tvvbtpkaKsEiLT0Ef51nFW/y5fqpOG5U0eU3cVsikZaYNlZ17x6O1wmvVCLdimQ==",
+      "requires": {
+        "@prismicio/helpers": "^2.3.8",
+        "@prismicio/types": "^0.2.7"
+      }
+    },
+    "@prismicio/helpers": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.3.8.tgz",
+      "integrity": "sha512-YHkEI2gHBRtNbMIEY8+ao9TLAqAMJSPbhGOAX9hiXHofcKSCBrpd9zaMxKNo5iXCWHnyBk1dsTsWXjKx0d1Rew==",
+      "requires": {
+        "@prismicio/richtext": "^2.1.3",
+        "@prismicio/types": "^0.2.7",
+        "escape-html": "^1.0.3",
+        "imgix-url-builder": "^0.0.3"
+      }
+    },
+    "@prismicio/react": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@prismicio/react/-/react-2.5.1.tgz",
+      "integrity": "sha512-gGF4UareQP1kdwtxNEbFyqWuFhQFqRjteMgsY7GxE0YKxKD3hByfUcKoFvSgkZIngk/boMpGRbRoE1S1Ouz2Jw==",
+      "requires": {
+        "@prismicio/helpers": "^2.3.8",
+        "@prismicio/richtext": "^2.1.3",
+        "@prismicio/types": "^0.2.7"
+      }
+    },
+    "@prismicio/richtext": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.1.3.tgz",
+      "integrity": "sha512-5ZuR+43CSf0R50+Asim+9B6csAezDMA+IF3V6MKGV8aWbNaVWmI3nSNDlKVKAe3peYtpkwQa8oVtUL5rsoXRIg==",
+      "requires": {
+        "@prismicio/types": "^0.2.7"
+      }
+    },
+    "@prismicio/types": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.7.tgz",
+      "integrity": "sha512-xHPBWg+lPcl8U97VB/2oYK3MJlQoVPZq91hbeQO8WRyvq+zgpNST3xFOTk8SkQpgoH6wd50AxGZELvPrpojajQ=="
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -59803,6 +59923,11 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+    },
+    "imgix-url-builder": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.3.tgz",
+      "integrity": "sha512-8Oc2Cn4+jF06sEfJcVPlWYfD2F6RjrwIMbk1xEzux8unoB5LsvFc/GL1BQ47HPaeE12ReX2nMUcjUslGYWLxHA=="
     },
     "immediate": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "@types/react-dom": "17.0.13",
     "@usedapp/core": "^1.0.1",
     "@walletconnect/web3-provider": "^1.7.8",
+    "@prismicio/client": "^6.6.1",
+    "@prismicio/react": "^2.4.2",
     "swiper": "^6.8.4",
     "pancake-swap-sdk": "^2.4.0"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,18 +1,29 @@
 import ReactDOM from 'react-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import { BrowserRouter } from 'react-router-dom';
+import ScrollTop from 'src/hooks/useScrollTop';
 
 import 'nprogress/nprogress.css';
 import App from 'src/App';
 import { SidebarProvider } from 'src/contexts/SidebarContext';
 import * as serviceWorker from 'src/serviceWorker';
+import web3connectors from 'src/util/web3connectors'
+import {PrismicProvider} from "@prismicio/react";
+import {client} from "./prismicio"
+import {DAppProvider} from "@usedapp/core";
+
 
 ReactDOM.render(
   <HelmetProvider>
     <SidebarProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+        <BrowserRouter>
+            <ScrollTop />
+            <PrismicProvider client={client}>
+                <DAppProvider config={web3connectors}>
+                    <App />
+                </DAppProvider>
+            </PrismicProvider>
+        </BrowserRouter>
     </SidebarProvider>
   </HelmetProvider>,
   document.getElementById('root')

--- a/src/prismicio.js
+++ b/src/prismicio.js
@@ -1,0 +1,13 @@
+import * as prismic from '@prismicio/client'
+
+export const repositoryName = 'aucry'
+
+export const client = prismic.createClient(repositoryName, {
+    accessToken: '',
+    routes: [
+        {
+            type: 'homepage',
+            path: '/',
+        },
+    ],
+})


### PR DESCRIPTION
This PR updates index to wire in the providers for usedApp & prismic. During the initial port of dependencies, I omitted prismic, so this PR gets that imported too.